### PR TITLE
set default None argument for ConfigurationError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.2 - 04/26/2024**
+
+ - Allow default None argument for ConfigurationError
+
 **1.0.1 - 04/11/2024**
 
  - Extract python version test matrix from python_versions.json

--- a/src/layered_config_tree/exceptions.py
+++ b/src/layered_config_tree/exceptions.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 class ConfigurationError(Exception):
     """Base class for configuration errors."""
 
-    def __init__(self, message: str, value_name: Optional[str]):
+    def __init__(self, message: str, value_name: Optional[str] = None):
         super().__init__(message)
         self.value_name = value_name
 


### PR DESCRIPTION
## Set default None argument for ConfigurationError
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
set default None argument for ConfigurationError

### Testing
Automated tests pass

