### PR TITLE
create iterator for LayeredConfigTree to solve typing errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.0.2 - 08/01/2024**
+
+ - Create explicit iterator for LayeredConfigTree
+
 **2.0.1 - 06/14/2024**
 
  - Add py.typed marker

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,9 +35,9 @@ copyright = f'2024, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = layered_config_tree.__version__  # type: ignore[attr-defined]
+version = layered_config_tree.__version__
 # The full version, including alpha/beta/rc tags.
-release = layered_config_tree.__version__  # type: ignore[attr-defined]
+release = layered_config_tree.__version__
 
 
 # -- General configuration ------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ profile = "black"
 # Avoid changing this!
 strict = true  # See all the enabled flags `mypy --help | grep -A 10 'Strict mode'`
 disallow_any_unimported = false
+implicit_reexport = true
 exclude = [
     "build",
 ]

--- a/src/layered_config_tree/__init__.py
+++ b/src/layered_config_tree/__init__.py
@@ -7,17 +7,6 @@ from layered_config_tree.__about__ import (
     __title__,
     __uri__,
 )
-
-# FIXME: Is there a better way to get around mypy error
-# "error: Module "layered_config_tree" does not explicitly export attribute "ConfigurationKeyError"  [attr-defined]"
-__all__ = [
-    "ConfigNode",
-    "ConfigurationError",
-    "ConfigurationKeyError",
-    "DuplicatedConfigurationError",
-    "LayeredConfigTree",
-]
-
 from layered_config_tree._version import __version__
 from layered_config_tree.exceptions import (
     ConfigurationError,

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -225,6 +225,23 @@ class ConfigNode:
         return f"{layer}: {value}"
 
 
+class ConfigIterator:
+    """
+    An iterator for a LayeredConfigTree object.
+
+    This iterator is used to iterate over the keys of a LayeredConfigTree object.
+    """
+
+    def __init__(self, config_tree: "LayeredConfigTree"):
+        self._iterator = iter(config_tree._children)
+
+    def __iter__(self) -> "ConfigIterator":
+        return self
+
+    def __next__(self) -> str:
+        return next(self._iterator)
+
+
 class LayeredConfigTree:
     """A container for configuration information.
 
@@ -560,9 +577,9 @@ class LayeredConfigTree:
         """Test if a configuration key exists in any layer."""
         return name in self._children
 
-    def __iter__(self) -> Iterable[str]:
+    def __iter__(self) -> ConfigIterator:
         """Dictionary-like iteration."""
-        return iter(self._children)
+        return ConfigIterator(self)
 
     def __len__(self) -> int:
         return len(self._children)


### PR DESCRIPTION
## Create iterator for LayeredConfigTree to solve typing errors
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5184

### Changes and notes
- `__iter__` was previously incorrectly typed
- Create iterator for LayeredConfigTree so that we don't need to
  expose the fact that we are iterating over a dictionary to the user.
- add implicit reexport so that we can remove `__all__` from the `__init__.py`

### Testing
Ran all unit tests here and in pseudopeople

