### PR TITLE
remove node value and nesteddict types

### DIFF
--- a/src/layered_config_tree/exceptions.py
+++ b/src/layered_config_tree/exceptions.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from layered_config_tree.types import NestedDictValue
+from typing import Any, Optional
 
 
 class ConfigurationError(Exception):
@@ -37,7 +35,7 @@ class DuplicatedConfigurationError(ConfigurationError):
         name: str,
         layer: Optional[str],
         source: Optional[str],
-        value: NestedDictValue,
+        value: Any,
     ):
         self.layer = layer
         self.source = source

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -40,7 +40,7 @@ from layered_config_tree import (
     ConfigurationKeyError,
     DuplicatedConfigurationError,
 )
-from layered_config_tree.types import InputData, NestedDict
+from layered_config_tree.types import InputData
 
 
 class ConfigNode:
@@ -332,7 +332,7 @@ class LayeredConfigTree:
                     unused.append(f"{name}.{grandchild_name}")
         return unused
 
-    def to_dict(self) -> NestedDict:
+    def to_dict(self) -> dict[str, Any]:
         """Converts the LayeredConfigTree into a nested dictionary.
 
         All metadata is lost in this conversion.
@@ -446,7 +446,7 @@ class LayeredConfigTree:
             for k, v in data.items():
                 self._set_with_metadata(k, v, layer, source)
 
-    def metadata(self, name: str) -> list[NestedDict]:
+    def metadata(self, name: str) -> list[dict[str, Any]]:
         if name in self:
             return self._children[name].metadata  # type: ignore[return-value]
         name = f"{self._name}.{name}" if self._name else name
@@ -456,7 +456,7 @@ class LayeredConfigTree:
     def _coerce(
         data: InputData,
         source: Optional[str],
-    ) -> tuple[NestedDict, Optional[str]]:
+    ) -> tuple[dict[str, Any], Optional[str]]:
         """Coerces data into dictionary format."""
         if isinstance(data, dict):
             return data, source
@@ -580,10 +580,10 @@ class LayeredConfigTree:
     # * Calling __getattr__ before we have set up the state doesn't work,
     #   because it leads to an infinite loop looking for the module's
     #   actual attributes (not config keys)
-    def __getstate__(self) -> NestedDict:
+    def __getstate__(self) -> dict[str, Any]:
         return self.__dict__
 
-    def __setstate__(self, state: NestedDict) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         for k, v in state.items():
             self.__dict__[k] = v
 

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -232,10 +232,10 @@ class ConfigIterator:
     This iterator is used to iterate over the keys of a LayeredConfigTree object.
     """
 
-    def __init__(self, config_tree: "LayeredConfigTree"):
+    def __init__(self, config_tree: LayeredConfigTree):
         self._iterator = iter(config_tree._children)
 
-    def __iter__(self) -> "ConfigIterator":
+    def __iter__(self) -> ConfigIterator:
         return self
 
     def __next__(self) -> str:
@@ -252,7 +252,7 @@ class LayeredConfigTree:
 
     # Define type annotations here since they're indirectly defined below
     _layers: list[str]
-    _children: dict[str, Union["LayeredConfigTree", "ConfigNode"]]
+    _children: dict[str, Union[LayeredConfigTree, ConfigNode]]
     _frozen: bool
     _name: str
 
@@ -308,7 +308,7 @@ class LayeredConfigTree:
         for child in self.values():
             child.freeze()
 
-    def items(self) -> Iterable[tuple[str, Union["LayeredConfigTree", ConfigNode]]]:
+    def items(self) -> Iterable[tuple[str, Union[LayeredConfigTree, ConfigNode]]]:
         """Return an iterable of all (child_name, child) pairs."""
         return self._children.items()
 

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Union
+from typing import TYPE_CHECKING, Any, Mapping, Union
 
 if TYPE_CHECKING:
     from layered_config_tree import LayeredConfigTree
@@ -8,14 +8,7 @@ if TYPE_CHECKING:
 # NOTE: py 3.9 does not support typing.TypeAlias
 
 # Define a nested dictionary of unknown depth for type hinting
-NestedDict = Mapping[str, "NestedDictValue"]
-# Define the leaf (ConfigNode) values (which cannot be another dictionary)
-NodeValue = Union[str, int, float, list[Union[str, int, float]], None]
-# Define a NestedDictionary value which can be either a ConfigNodeValue or another NestedDict
-# NOTE: Due to the forward reference to NestedDictValue above, static type checkers
-#   (e.g. mypy) may not be able to determine the correct type of NestedDictValue;
-#   use # type: ignore as required
-NestedDictValue = Union[NodeValue, NestedDict]
+NestedDict = Mapping[str, Any]
 
 # Data input types
 InputData = Union[NestedDict, str, Path, "LayeredConfigTree"]

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Union
 

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Union
+from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
     from layered_config_tree import LayeredConfigTree

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
     from layered_config_tree import LayeredConfigTree

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -5,4 +5,4 @@ if TYPE_CHECKING:
     from layered_config_tree import LayeredConfigTree
 
 # Data input types
-InputData = Union[dict[str, Any], str, Path, "LayeredConfigTree"]
+InputData = Union[dict[str, Any], str, Path, LayeredConfigTree]

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any, Union
 
-if TYPE_CHECKING:
-    from layered_config_tree import LayeredConfigTree
 
 # Data input types
-InputData = Union[dict[str, Any], str, Path, LayeredConfigTree]
+InputData = Union[dict[str, Any], str, Path, "LayeredConfigTree"]

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from layered_config_tree import LayeredConfigTree
 
 # Data input types
 InputData = Union[dict[str, Any], str, Path, "LayeredConfigTree"]

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -3,6 +3,5 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Union
 
-
 # Data input types
 InputData = Union[dict[str, Any], str, Path, "LayeredConfigTree"]

--- a/src/layered_config_tree/types.py
+++ b/src/layered_config_tree/types.py
@@ -4,11 +4,5 @@ from typing import TYPE_CHECKING, Any, Mapping, Union
 if TYPE_CHECKING:
     from layered_config_tree import LayeredConfigTree
 
-
-# NOTE: py 3.9 does not support typing.TypeAlias
-
-# Define a nested dictionary of unknown depth for type hinting
-NestedDict = Mapping[str, Any]
-
 # Data input types
-InputData = Union[NestedDict, str, Path, "LayeredConfigTree"]
+InputData = Union[dict[str, Any], str, Path, "LayeredConfigTree"]

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -12,7 +12,7 @@ from layered_config_tree import (
     DuplicatedConfigurationError,
     LayeredConfigTree,
 )
-from layered_config_tree.types import NestedDict
+from typing import Any
 
 
 @pytest.fixture(params=list(range(1, 5)))
@@ -44,7 +44,7 @@ def empty_tree(layers: list[str]) -> LayeredConfigTree:
 
 
 @pytest.fixture
-def getter_dict() -> NestedDict:
+def getter_dict() -> dict[str, Any]:
     return {
         "outer_layer_1": "test_value",
         "outer_layer_2": {"inner_layer": "test_value2"},
@@ -251,7 +251,7 @@ def test_tree_creation(empty_tree: LayeredConfigTree) -> None:
 
 
 def test_tree_coerce_dict() -> None:
-    data: NestedDict
+    data: dict[str, Any]
     data = {}
     src = "test"
     assert LayeredConfigTree._coerce(data, src) == (data, src)
@@ -475,7 +475,7 @@ def test_to_dict_yaml(test_spec: Path) -> None:
     ],
 )
 def test_getter_single_values(
-    key: str, default_value: str, expected_value: str, getter_dict: NestedDict
+    key: str, default_value: str, expected_value: str, getter_dict: dict[str, Any]
 ) -> None:
     lct = LayeredConfigTree(getter_dict)
 
@@ -485,7 +485,7 @@ def test_getter_single_values(
         assert lct.get(key, default_value) == expected_value
 
 
-def test_getter_chained(getter_dict: NestedDict) -> None:
+def test_getter_chained(getter_dict: dict[str, Any]) -> None:
     lct = LayeredConfigTree(getter_dict)
 
     outer_layer_2 = lct.get("outer_layer_2")
@@ -494,7 +494,7 @@ def test_getter_chained(getter_dict: NestedDict) -> None:
     assert outer_layer_2.get("inner_layer") == "test_value2"
 
 
-def test_getter_default_values(getter_dict: NestedDict) -> None:
+def test_getter_default_values(getter_dict: dict[str, Any]) -> None:
     lct = LayeredConfigTree(getter_dict)
 
     assert lct.get("fake_key") is None
@@ -505,7 +505,7 @@ def test_getter_default_values(getter_dict: NestedDict) -> None:
     assert default_value.get("another_fake_key") is None
 
 
-def test_tree_getter(getter_dict: NestedDict) -> None:
+def test_tree_getter(getter_dict: dict[str, Any]) -> None:
     lct = LayeredConfigTree(getter_dict)
 
     assert lct.get_tree("outer_layer_2").to_dict() == getter_dict["outer_layer_2"]

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -1,6 +1,7 @@
 import pickle
 import textwrap
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -12,7 +13,6 @@ from layered_config_tree import (
     DuplicatedConfigurationError,
     LayeredConfigTree,
 )
-from typing import Any
 
 
 @pytest.fixture(params=list(range(1, 5)))


### PR DESCRIPTION
## remove node value and nesteddict types

### Description
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5359

### Changes and notes
Remove NodeValue and NestedDict types. We'd like to type NodeValue as Any except Dict which doesn't seem possible right now.

### Testing
mypy passes.

