### PR TITLE
Support dunder keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.0 - 02/14/2025**
+
+ - Better handle dunder-style keys
+
 **2.2.1 - 12/27/2024**
 
  - Bugfix: failing mypy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.0.0 - 02/14/2025**
+**3.0.0 - 02/18/2025**
 
  - Better handle dunder-style keys
 

--- a/src/layered_config_tree/__init__.py
+++ b/src/layered_config_tree/__init__.py
@@ -12,5 +12,6 @@ from layered_config_tree.exceptions import (
     ConfigurationError,
     ConfigurationKeyError,
     DuplicatedConfigurationError,
+    ImproperAccessError,
 )
 from layered_config_tree.main import ConfigNode, LayeredConfigTree

--- a/src/layered_config_tree/exceptions.py
+++ b/src/layered_config_tree/exceptions.py
@@ -15,6 +15,12 @@ class ConfigurationKeyError(ConfigurationError, KeyError):
     pass
 
 
+class ImproperAccessError(ConfigurationError):
+    """Error raised when a configuration value is accessed improperly."""
+
+    pass
+
+
 class DuplicatedConfigurationError(ConfigurationError):
     """Error raised when a configuration value is set more than once.
 

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -565,7 +565,7 @@ class LayeredConfigTree:
         if name.startswith("__") and name.endswith("__"):
             raise RuntimeError(
                 "Cannot set an attribute starting and ending with '__' via attribute "
-                "access (i.e. dot notation). Use dicationary access instead "
+                "access (i.e. dot notation). Use dictionary access instead "
                 "(i.e. bracket notation)."
             )
         self._set_with_metadata(name, value, layer=None, source=None)

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -39,6 +39,7 @@ from layered_config_tree import (
     ConfigurationError,
     ConfigurationKeyError,
     DuplicatedConfigurationError,
+    ImproperAccessError,
 )
 from layered_config_tree.types import InputData
 
@@ -563,7 +564,7 @@ class LayeredConfigTree:
                 self._name,
             )
         if name.startswith("__") and name.endswith("__"):
-            raise RuntimeError(
+            raise ImproperAccessError(
                 "Cannot set an attribute starting and ending with '__' via attribute "
                 "access (i.e. dot notation). Use dictionary access instead "
                 "(i.e. bracket notation)."
@@ -604,7 +605,7 @@ class LayeredConfigTree:
         if name.startswith("__") and name.endswith("__"):
             if name not in self:
                 raise AttributeError  # Do not change from AttributeError
-            raise RuntimeError(
+            raise ImproperAccessError(
                 "Cannot get an attribute starting and ending with '__' via attribute "
                 "access (i.e. dot notation). Use dictionary access instead "
                 "(i.e. bracket notation)."

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -382,9 +382,12 @@ def test_get_missing_key() -> None:
 
 def test_set_missing_key() -> None:
     lct = LayeredConfigTree()
-    with pytest.raises(ConfigurationKeyError):
+    error_msg = re.escape(
+        "New configuration keys can only be created with the update method."
+    )
+    with pytest.raises(ConfigurationKeyError, match=error_msg):
         lct.missing_key = "test_value"
-    with pytest.raises(ConfigurationKeyError):
+    with pytest.raises(ConfigurationKeyError, match=error_msg):
         lct["missing_key"] = "test_value"
 
 

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import textwrap
 from pathlib import Path
 from typing import Any
@@ -341,6 +342,36 @@ def test_dictionary_style_access() -> None:
 
     assert lct["test_key2"] == "test_value2"
     assert lct["test_key"] == "test_value"
+
+
+def test_dunder_key_attr_style_access() -> None:
+    lct = LayeredConfigTree()
+    lct.update({"__dunder_key__": "val"})
+    assert lct["__dunder_key__"] == "val"
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Cannot get an attribute starting and ending with '__' via attribute "
+            "access (i.e. dot notation). Use dictionary access instead "
+            "(i.e. bracket notation)."
+        ),
+    ):
+        lct.__dunder_key__
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Cannot set an attribute starting and ending with '__' via attribute "
+            "access (i.e. dot notation). Use dicationary access instead "
+            "(i.e. bracket notation)."
+        ),
+    ):
+        lct.__dunder_key__ = "val2"
+    assert lct["__dunder_key__"] == "val"
+
+    with pytest.raises(AttributeError):
+        lct.__non_existent_dunder_key__
 
 
 def test_get_missing_key() -> None:

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -363,7 +363,7 @@ def test_dunder_key_attr_style_access() -> None:
         RuntimeError,
         match=re.escape(
             "Cannot set an attribute starting and ending with '__' via attribute "
-            "access (i.e. dot notation). Use dicationary access instead "
+            "access (i.e. dot notation). Use dictionary access instead "
             "(i.e. bracket notation)."
         ),
     ):

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -345,8 +345,8 @@ def test_dictionary_style_access() -> None:
 
 
 def test_dunder_key_attr_style_access() -> None:
-    lct = LayeredConfigTree()
-    lct.update({"__dunder_key__": "val"})
+    lct = LayeredConfigTree({"__dunder_key__": "val"}, layers=["layer1", "layer2"])
+    # lct.update({"__dunder_key__": "val"})
     assert lct["__dunder_key__"] == "val"
 
     with pytest.raises(
@@ -369,6 +369,10 @@ def test_dunder_key_attr_style_access() -> None:
     ):
         lct.__dunder_key__ = "val2"
     assert lct["__dunder_key__"] == "val"
+
+    # check that we can modify the value in a new layer
+    lct["__dunder_key__"] = "val2"
+    assert lct["__dunder_key__"] == "val2"
 
     with pytest.raises(AttributeError):
         lct.__non_existent_dunder_key__

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -12,6 +12,7 @@ from layered_config_tree import (
     ConfigurationError,
     ConfigurationKeyError,
     DuplicatedConfigurationError,
+    ImproperAccessError,
     LayeredConfigTree,
 )
 
@@ -350,7 +351,7 @@ def test_dunder_key_attr_style_access() -> None:
     assert lct["__dunder_key__"] == "val"
 
     with pytest.raises(
-        RuntimeError,
+        ImproperAccessError,
         match=re.escape(
             "Cannot get an attribute starting and ending with '__' via attribute "
             "access (i.e. dot notation). Use dictionary access instead "
@@ -360,7 +361,7 @@ def test_dunder_key_attr_style_access() -> None:
         lct.__dunder_key__
 
     with pytest.raises(
-        RuntimeError,
+        ImproperAccessError,
         match=re.escape(
             "Cannot set an attribute starting and ending with '__' via attribute "
             "access (i.e. dot notation). Use dictionary access instead "


### PR DESCRIPTION
## Support dunder-style keys

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5863

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This better handles dunder-style keys (e.g. "__some_key__") so that it does not
conflict with dunder methods and functions.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
all tests pass, incl new one.
