### PR TITLE
Raise if duplicate keys exist

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @collijk @hussain-jafari @patricktnast @rmudambi @stevebachmeier
+* @albrja @hussain-jafari @patricktnast @rmudambi @stevebachmeier

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**4.0.0 - 03/13/2025**
+**3.1.0 - 03/13/2025**
 
  - Raise an error if YAML contains duplicate keys within the same level
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.0 - 03/13/2025**
+**3.1.0 - 03/18/2025**
 
  - Raise an error if YAML contains duplicate keys within the same level
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.0.0 - 03/13/2025**
+
+ - Raise an error if YAML contains duplicate keys within the same level
+
 **3.0.0 - 02/18/2025**
 
  - Better handle dunder-style keys

--- a/src/layered_config_tree/__init__.py
+++ b/src/layered_config_tree/__init__.py
@@ -12,6 +12,7 @@ from layered_config_tree.exceptions import (
     ConfigurationError,
     ConfigurationKeyError,
     DuplicatedConfigurationError,
+    DuplicateKeysInYAMLError,
     ImproperAccessError,
 )
 from layered_config_tree.main import ConfigNode, LayeredConfigTree, load_yaml

--- a/src/layered_config_tree/__init__.py
+++ b/src/layered_config_tree/__init__.py
@@ -14,4 +14,4 @@ from layered_config_tree.exceptions import (
     DuplicatedConfigurationError,
     ImproperAccessError,
 )
-from layered_config_tree.main import ConfigNode, LayeredConfigTree
+from layered_config_tree.main import ConfigNode, LayeredConfigTree, load_yaml

--- a/src/layered_config_tree/__init__.py
+++ b/src/layered_config_tree/__init__.py
@@ -12,7 +12,6 @@ from layered_config_tree.exceptions import (
     ConfigurationError,
     ConfigurationKeyError,
     DuplicatedConfigurationError,
-    DuplicateKeysInYAMLError,
     ImproperAccessError,
 )
 from layered_config_tree.main import ConfigNode, LayeredConfigTree, load_yaml

--- a/src/layered_config_tree/exceptions.py
+++ b/src/layered_config_tree/exceptions.py
@@ -47,3 +47,9 @@ class DuplicatedConfigurationError(ConfigurationError):
         self.source = source
         self.value = value
         super().__init__(message, name)
+
+
+class DuplicateKeysInYAMLError(ConfigurationError):
+    """Error raised when a YAML file contains duplicate keys."""
+
+    pass

--- a/src/layered_config_tree/exceptions.py
+++ b/src/layered_config_tree/exceptions.py
@@ -47,9 +47,3 @@ class DuplicatedConfigurationError(ConfigurationError):
         self.source = source
         self.value = value
         super().__init__(message, name)
-
-
-class DuplicateKeysInYAMLError(ConfigurationError):
-    """Error raised when a YAML file contains duplicate keys."""
-
-    pass

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -464,17 +464,17 @@ class LayeredConfigTree:
         elif (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(
             data, Path
         ):
+            # 'data' is a filepath to a yaml file
             source = source if source else str(data)
-            with open(data) as f:
-                data_file = f.read()
-            coerced_data = yaml.full_load(data_file)
+            coerced_data = load_yaml(data)
             if not isinstance(coerced_data, dict):
                 raise ValueError(
                     f"Loaded yaml file {coerced_data} should be a dictionary but is type {type(coerced_data)}"
                 )
             return coerced_data, source
         elif isinstance(data, str):
-            data = yaml.full_load(data)
+            # 'data' is a yaml string
+            data = load_yaml(data)
             if not isinstance(data, dict):
                 raise ValueError(
                     f"Loaded yaml file {data} should be a dictionary but is type {type(data)}"
@@ -671,3 +671,39 @@ class LayeredConfigTree:
 
     def __eq__(self, other: object) -> bool:
         raise NotImplementedError
+
+
+# class UniqueKeyHandler(SafeLoader):
+#     ...
+
+
+def load_yaml(data: str | Path) -> dict[str, Any]:
+    """Loads a YAML filepath or string into a dictionary.
+
+    Parameters
+    ----------
+    data
+        The YAML content to load. This can be a file path to a YAML file or a string
+        containing YAML-formatted text.
+
+    Returns
+    -------
+        A dictionary representation of the loaded YAML content.
+
+    Notes
+    -----
+    If `data` is a Path object or a string that ends with ".yaml" or ".yml", it is
+    treated as a filepath and this function loads the file. Otherwise, `data` is a
+    string that does _not_ end in ".yaml" or ".yml" and it is treated as YAML-formatted
+    text which is loaded directly into a dictionary.
+    """
+
+    if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(data, Path):
+        # 'data' is a filepath to a yaml file
+        with open(data) as f:
+            data_file = f.read()
+        data_dict = yaml.safe_load(data_file)
+    else:
+        # 'data' is a yaml string
+        data_dict = yaml.safe_load(data)
+    return data_dict

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -39,8 +39,8 @@ from layered_config_tree import (
     DuplicatedConfigurationError,
     ImproperAccessError,
 )
-from layered_config_tree.utilities import load_yaml
 from layered_config_tree.types import InputData
+from layered_config_tree.utilities import load_yaml
 
 
 class ConfigNode:

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -29,11 +29,9 @@ For example:
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from layered_config_tree import (
     ConfigurationError,
@@ -41,6 +39,7 @@ from layered_config_tree import (
     DuplicatedConfigurationError,
     ImproperAccessError,
 )
+from layered_config_tree.utilities import load_yaml
 from layered_config_tree.types import InputData
 
 
@@ -461,10 +460,10 @@ class LayeredConfigTree:
         """Coerces data into dictionary format."""
         if isinstance(data, dict):
             return data, source
-        
+
         if isinstance(data, LayeredConfigTree):
             return data.to_dict(), source
-        
+
         coerced_data = load_yaml(data)
         if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(
             data, Path
@@ -672,97 +671,3 @@ class LayeredConfigTree:
 
     def __eq__(self, other: object) -> bool:
         raise NotImplementedError
-
-
-def load_yaml(data: str | Path) -> dict[str, Any]:
-    """Loads a YAML filepath or string into a dictionary.
-
-    Parameters
-    ----------
-    data
-        The YAML content to load. This can be a file path to a YAML file or a string
-        containing YAML-formatted text.
-
-    Returns
-    -------
-        A dictionary representation of the loaded YAML content.
-
-    Notes
-    -----
-    If `data` is a Path object or a string that ends with ".yaml" or ".yml", it is
-    treated as a filepath and this function loads the file. Otherwise, `data` is a
-    string that does _not_ end in ".yaml" or ".yml" and it is treated as YAML-formatted
-    text which is loaded directly into a dictionary.
-    """
-
-    data_dict: dict[str, Any]
-    if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(data, Path):
-        # 'data' is a filepath to a yaml file
-        with open(data) as f:
-            data_file = f.read()
-        data_dict = yaml.load(data_file, Loader=SafeLoader)
-    else:
-        # 'data' is a yaml string
-        data_dict = yaml.load(data, Loader=SafeLoader)
-    return data_dict
-
-
-class SafeLoader(yaml.SafeLoader):
-    """A yaml.SafeLoader that restricts duplicate keys."""
-
-    def construct_mapping(
-        self,
-        node: yaml.MappingNode,
-        deep: bool = False,
-        path: list[str] | None = None,
-    ) -> dict[Hashable, Any]:
-        """Constructs the standard mapping after checking for duplicates.
-
-        Parameters
-        ----------
-        node
-            The YAML mapping node to construct.
-        deep
-            Whether or not to recursively construct mappings.
-        path
-            The path to the current node in the YAML document.
-
-        Raises
-        ------
-        DuplicateKeysInYAMLError
-            If duplicate keys within the same level are detected in the YAML file
-            being loaded.
-
-        Notes
-        -----
-        The duplicate key check is performed _only at the level of the mapping being
-        currently constructed_. This means that if the YAML document contains nested
-        mappings, each mapping is checked independently for duplicates. As a result,
-        fixing a duplicate in one level of the document will not prevent this method
-        from raising an error for duplicates in another upon subsequent loads.
-        """
-        path = [] if path is None else path
-        seen = set()
-        duplicates = {}
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
-            full_path = path + [key]
-            if key in seen:
-                duplicates[key] = full_path
-            else:
-                seen.add(key)
-            # update path
-            if isinstance(value_node, yaml.MappingNode):
-                self.construct_mapping(value_node, deep, full_path)
-        if duplicates:
-            formatted_duplicates = "\n".join(
-                [f"* {'-'.join(map(str, v))}" for v in duplicates.values()]
-            )
-            raise DuplicatedConfigurationError(
-                f"Duplicate key(s) detected in YAML file being loaded:\n{formatted_duplicates}",
-                name=f"duplicates_{'_'.join(duplicates)}",
-                layer=None,
-                source=None,
-                value=None,
-            )
-        return super().construct_mapping(node, deep)

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -29,7 +29,7 @@ For example:
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -710,7 +710,9 @@ def load_yaml(data: str | Path) -> dict[str, Any]:
 class SafeLoader(yaml.SafeLoader):
     """A yaml.SafeLoader that restricts duplicate keys."""
 
-    def construct_mapping(self, node, deep=False):
+    def construct_mapping(
+        self, node: yaml.MappingNode, deep: bool = False
+    ) -> dict[Hashable, Any]:
         """Constructs the standard mapping after checking for duplicates.
 
         Raises
@@ -730,7 +732,7 @@ class SafeLoader(yaml.SafeLoader):
         mapping = []
         duplicates = []
         for key_node, _value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
+            key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
             if key in mapping:
                 duplicates.append(key)
             mapping.append(key)

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -461,12 +461,16 @@ class LayeredConfigTree:
         """Coerces data into dictionary format."""
         if isinstance(data, dict):
             return data, source
-        elif (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(
+        
+        if isinstance(data, LayeredConfigTree):
+            return data.to_dict(), source
+        
+        coerced_data = load_yaml(data)
+        if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(
             data, Path
         ):
             # 'data' is a filepath to a yaml file
             source = source if source else str(data)
-            coerced_data = load_yaml(data)
             if not isinstance(coerced_data, dict):
                 raise ValueError(
                     f"Loaded yaml file {coerced_data} should be a dictionary but is type {type(coerced_data)}"
@@ -474,14 +478,11 @@ class LayeredConfigTree:
             return coerced_data, source
         elif isinstance(data, str):
             # 'data' is a yaml string
-            data = load_yaml(data)
-            if not isinstance(data, dict):
+            if not isinstance(coerced_data, dict):
                 raise ValueError(
-                    f"Loaded yaml file {data} should be a dictionary but is type {type(data)}"
+                    f"Loaded yaml file {coerced_data} should be a dictionary but is type {type(coerced_data)}"
                 )
-            return data, source
-        elif isinstance(data, LayeredConfigTree):
-            return data.to_dict(), source
+            return coerced_data, source
         else:
             raise ConfigurationError(
                 f"LayeredConfigTree can only update from dictionaries, strings, paths and LayeredConfigTrees. "

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -460,31 +460,14 @@ class LayeredConfigTree:
         """Coerces data into dictionary format."""
         if isinstance(data, dict):
             return data, source
-
-        if isinstance(data, LayeredConfigTree):
+        elif isinstance(data, LayeredConfigTree):
             return data.to_dict(), source
-
-        coerced_data = load_yaml(data)
-        if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(
-            data, Path
-        ):
-            # 'data' is a filepath to a yaml file
+        elif isinstance(data, (str, Path)):
             source = source if source else str(data)
-            if not isinstance(coerced_data, dict):
-                raise ValueError(
-                    f"Loaded yaml file {coerced_data} should be a dictionary but is type {type(coerced_data)}"
-                )
-            return coerced_data, source
-        elif isinstance(data, str):
-            # 'data' is a yaml string
-            if not isinstance(coerced_data, dict):
-                raise ValueError(
-                    f"Loaded yaml file {coerced_data} should be a dictionary but is type {type(coerced_data)}"
-                )
-            return coerced_data, source
+            return load_yaml(data), source
         else:
             raise ConfigurationError(
-                f"LayeredConfigTree can only update from dictionaries, strings, paths and LayeredConfigTrees. "
+                f"LayeredConfigTree can only update from dictionaries, strings, paths, and LayeredConfigTrees. "
                 f"You passed in {type(data)}",
                 value_name=None,
             )

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -698,6 +698,7 @@ def load_yaml(data: str | Path) -> dict[str, Any]:
     text which is loaded directly into a dictionary.
     """
 
+    data_dict: dict[str, Any]
     if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(data, Path):
         # 'data' is a filepath to a yaml file
         with open(data) as f:

--- a/src/layered_config_tree/utilities.py
+++ b/src/layered_config_tree/utilities.py
@@ -1,0 +1,111 @@
+"""
+=========
+Utilities
+=========
+
+This module contains utility functions and classes for the layered_config_tree
+package.
+
+"""
+
+from collections.abc import Hashable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from layered_config_tree import DuplicatedConfigurationError
+
+
+def load_yaml(data: str | Path) -> dict[str, Any]:
+    """Loads a YAML filepath or string into a dictionary.
+
+    Parameters
+    ----------
+    data
+        The YAML content to load. This can be a file path to a YAML file or a string
+        containing YAML-formatted text.
+
+    Returns
+    -------
+        A dictionary representation of the loaded YAML content.
+
+    Notes
+    -----
+    If `data` is a Path object or a string that ends with ".yaml" or ".yml", it is
+    treated as a filepath and this function loads the file. Otherwise, `data` is a
+    string that does _not_ end in ".yaml" or ".yml" and it is treated as YAML-formatted
+    text which is loaded directly into a dictionary.
+    """
+
+    data_dict: dict[str, Any]
+    if (isinstance(data, str) and data.endswith((".yaml", ".yml"))) or isinstance(data, Path):
+        # 'data' is a filepath to a yaml file
+        with open(data) as f:
+            data_file = f.read()
+        data_dict = yaml.load(data_file, Loader=SafeLoader)
+    else:
+        # 'data' is a yaml string
+        data_dict = yaml.load(data, Loader=SafeLoader)
+    return data_dict
+
+
+class SafeLoader(yaml.SafeLoader):
+    """A yaml.SafeLoader that restricts duplicate keys."""
+
+    def construct_mapping(
+        self,
+        node: yaml.MappingNode,
+        deep: bool = False,
+        path: list[str] | None = None,
+    ) -> dict[Hashable, Any]:
+        """Constructs the standard mapping after checking for duplicates.
+
+        Parameters
+        ----------
+        node
+            The YAML mapping node to construct.
+        deep
+            Whether or not to recursively construct mappings.
+        path
+            The path to the current node in the YAML document.
+
+        Raises
+        ------
+        DuplicateKeysInYAMLError
+            If duplicate keys within the same level are detected in the YAML file
+            being loaded.
+
+        Notes
+        -----
+        The duplicate key check is performed _only at the level of the mapping being
+        currently constructed_. This means that if the YAML document contains nested
+        mappings, each mapping is checked independently for duplicates. As a result,
+        fixing a duplicate in one level of the document will not prevent this method
+        from raising an error for duplicates in another upon subsequent loads.
+        """
+        path = [] if path is None else path
+        seen = set()
+        duplicates = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
+            full_path = path + [key]
+            if key in seen:
+                duplicates[key] = full_path
+            else:
+                seen.add(key)
+            # update path
+            if isinstance(value_node, yaml.MappingNode):
+                self.construct_mapping(value_node, deep, full_path)
+        if duplicates:
+            formatted_duplicates = "\n".join(
+                [f"* {'-'.join(map(str, v))}" for v in duplicates.values()]
+            )
+            raise DuplicatedConfigurationError(
+                f"Duplicate key(s) detected in YAML file being loaded:\n{formatted_duplicates}",
+                name=f"duplicates_{'_'.join(duplicates)}",
+                layer=None,
+                source=None,
+                value=None,
+            )
+        return super().construct_mapping(node, deep)

--- a/src/layered_config_tree/utilities.py
+++ b/src/layered_config_tree/utilities.py
@@ -61,18 +61,21 @@ class SafeLoader(yaml.SafeLoader):
 
     def construct_mapping(self, node, deep=False):
         """Constructs the standard mapping after checking for duplicates.
+
         Raises
         ------
         DuplicateKeysInYAMLError
             If duplicate keys within the same level are detected in the YAML file
             being loaded.
+        
         Notes
         -----
-        The duplicate key check is performed _only at the level of the mapping being
-        currently constructed_. This means that if the YAML document contains nested
-        mappings, each mapping is checked independently for duplicates. As a result,
-        fixing a duplicate in one level of the document will not prevent this method
-        from raising an error for duplicates in another upon subsequent loads.
+        A key is considered a duplicate only if it is the sa me as another key
+        _at the same level in the YAML_.
+
+        This raises upon the _first_ duplicate key found; other duplicates may exist
+        (in which case a new error will be raised upon re-loading of the YAML file
+        once the duplicate is resolved).
         """
         mapping = []
         for key_node, _value_node in node.value:

--- a/src/layered_config_tree/utilities.py
+++ b/src/layered_config_tree/utilities.py
@@ -8,6 +8,7 @@ package.
 
 """
 
+from collections.abc import Hashable
 from pathlib import Path
 from typing import Any
 
@@ -59,7 +60,9 @@ def load_yaml(data: str | Path) -> dict[str, Any]:
 class SafeLoader(yaml.SafeLoader):
     """A yaml.SafeLoader that restricts duplicate keys."""
 
-    def construct_mapping(self, node, deep=False):
+    def construct_mapping(
+        self, node: yaml.MappingNode, deep: bool = False
+    ) -> dict[Hashable, Any]:
         """Constructs the standard mapping after checking for duplicates.
 
         Raises
@@ -79,7 +82,7 @@ class SafeLoader(yaml.SafeLoader):
         """
         mapping = []
         for key_node, _value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
+            key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
             if key in mapping:
                 raise DuplicatedConfigurationError(
                     f"Duplicate key detected at same level of YAML: {key}. Resolve duplicates and try again.",

--- a/src/layered_config_tree/utilities.py
+++ b/src/layered_config_tree/utilities.py
@@ -73,7 +73,7 @@ class SafeLoader(yaml.SafeLoader):
 
         Notes
         -----
-        A key is considered a duplicate only if it is the sa me as another key
+        A key is considered a duplicate only if it is the same as another key
         _at the same level in the YAML_.
 
         This raises upon the _first_ duplicate key found; other duplicates may exist

--- a/src/layered_config_tree/utilities.py
+++ b/src/layered_config_tree/utilities.py
@@ -67,7 +67,7 @@ class SafeLoader(yaml.SafeLoader):
         DuplicateKeysInYAMLError
             If duplicate keys within the same level are detected in the YAML file
             being loaded.
-        
+
         Notes
         -----
         A key is considered a duplicate only if it is the sa me as another key

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -14,6 +14,7 @@ from layered_config_tree import (
     DuplicatedConfigurationError,
     ImproperAccessError,
     LayeredConfigTree,
+    load_yaml,
 )
 
 
@@ -500,8 +501,7 @@ def test_to_dict_dict() -> None:
 
 def test_to_dict_yaml(test_spec: Path) -> None:
     lct = LayeredConfigTree(str(test_spec))
-    with test_spec.open() as f:
-        yaml_config = yaml.full_load(f)
+    yaml_config = load_yaml(test_spec)
     assert yaml_config == lct.to_dict()
 
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -63,11 +63,11 @@ def test_load_yaml_file(tmp_path: Path, path_type: type[str | Path]) -> None:
 def test_load_yaml_duplicates_raise(
     duplicates: bool, load_from_file: bool, tmp_path: Path
 ) -> None:
-    test_yaml = TEST_YAML_DUPLICATE_KEYS if duplicates else TEST_YAML_ONE
+    test_str: str = TEST_YAML_DUPLICATE_KEYS if duplicates else TEST_YAML_ONE
     if load_from_file:
         tmp_file = tmp_path / "test_dupliate_keys.yaml"
-        tmp_file.write_text(test_yaml)
-        test_yaml = tmp_file
+        tmp_file.write_text(test_str)
+    test_yaml = tmp_file if load_from_file else test_str
 
     lct = LayeredConfigTree()
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from layered_config_tree import LayeredConfigTree
 
 TEST_YAML_ONE = """
@@ -21,12 +23,14 @@ def test_load_yaml_string() -> None:
     assert lct.test_section2.test_key == "test_value3"
 
 
-def test_load_yaml_file(tmp_path: Path) -> None:
+@pytest.mark.parametrize("path_type", [str, Path])
+def test_load_yaml_file(tmp_path: Path, path_type: type[str | Path]) -> None:
     tmp_file = tmp_path / "test_file.yaml"
     tmp_file.write_text(TEST_YAML_ONE)
 
     lct = LayeredConfigTree()
-    lct.update(str(tmp_file))
+    filepath_to_test = str(tmp_file) if path_type is str else tmp_file
+    lct.update(filepath_to_test)
 
     assert lct.test_section.test_key == "test_value"
     assert lct.test_section.test_key2 == "test_value2"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -65,7 +65,7 @@ def test_load_yaml_duplicates_raise(
 ) -> None:
     test_str: str = TEST_YAML_DUPLICATE_KEYS if duplicates else TEST_YAML_ONE
     if load_from_file:
-        tmp_file = tmp_path / "test_dupliate_keys.yaml"
+        tmp_file = tmp_path / "test_duplicate_keys.yaml"
         tmp_file.write_text(test_str)
     test_yaml = tmp_file if load_from_file else test_str
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -24,14 +24,14 @@ cats:
         color: brown
     garfield:
         size: chonky
-        features:
+        traits:
             - lazy
-            - fat
+            - grumpy
         color: orange
         size:
             - thick
-        features:
-            - lasagna lover
+        traits:
+            - loves lasagna
 """
 
 
@@ -69,7 +69,7 @@ def test_load_yaml_duplicates(tmp_path: Path, duplicates: bool) -> None:
         with pytest.raises(
             ConfigurationError,
             match=re.escape(
-                "Duplicate key(s) detected in YAML file being loaded: ['size', 'features']"
+                "Duplicate key(s) detected in YAML file being loaded: ['size', 'traits']"
             ),
         ):
             lct.update(tmp_file)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -27,11 +27,11 @@ cats:
         traits:
             - lazy
             - grumpy
-        color: orange
-        size:
-            - thick
-        traits:
             - loves lasagna
+        color: orange
+        size: thick  # first duplicate; we raise here
+        color: brown  # second duplicate; no raise
+
 """
 
 
@@ -69,7 +69,7 @@ def test_load_yaml_duplicates(tmp_path: Path, duplicates: bool) -> None:
         with pytest.raises(
             DuplicatedConfigurationError,
             match=re.escape(
-                "Duplicate key(s) detected in YAML file being loaded:\n* cats-garfield-size\n* cats-garfield-traits"
+                "Duplicate key(s) detected in YAML file being loaded: cats-garfield-size"
             ),
         ):
             lct.update(tmp_file)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from layered_config_tree import ConfigurationError, LayeredConfigTree
+from layered_config_tree import DuplicatedConfigurationError, LayeredConfigTree
 
 TEST_YAML_ONE = """
 test_section:
@@ -67,9 +67,9 @@ def test_load_yaml_duplicates(tmp_path: Path, duplicates: bool) -> None:
     lct = LayeredConfigTree()
     if duplicates:
         with pytest.raises(
-            ConfigurationError,
+            DuplicatedConfigurationError,
             match=re.escape(
-                "Duplicate key(s) detected in YAML file being loaded: ['size', 'traits']"
+                "Duplicate key(s) detected in YAML file being loaded:\n* cats-garfield-size\n* cats-garfield-traits"
             ),
         ):
             lct.update(tmp_file)


### PR DESCRIPTION
## Raise if duplicate keys exist
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5256

### Changes and notes
Yaml does not support default keys. However, default yaml.load() behavior is 
not to error in the event the file has some, but rather to overwrite duplicates.
This is why if you load a yaml file like
```
key1: foo
key2: bar
key1: baz
```
you end up w/
```
key2: bar
key1: baz
```

This PR extends the pyyaml SafeLoader to check for duplicate keys and raise
if it finds any.

And since I was here, I converted the loader from FullLoader to SafeLoader.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

