### PR TITLE
Sbachmei/mic 5488/get nested tree

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.2.0 - 03/31/2025**
+
+ - Get nested values from a single 'get' or 'get_tree' call
+
 **3.1.0 - 03/18/2025**
 
  - Raise an error if YAML contains duplicate keys within the same level

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -346,33 +346,80 @@ class LayeredConfigTree:
                 result[name] = child.to_dict()
         return result
 
-    def get(self, key: str, default_value: Any = None) -> Any:
-        """Return the LayeredConfigTree or value at the key in the outermost layer of the config tree.
+    def get(self, keys: str | list[str], default_value: Any = None) -> Any:
+        """Return the value at the key or key path in the outermost layer.
 
         Parameters
         ----------
-        key
-            The string to look for in the outermost layer of the config tree.
+        keys
+            The string or ordered list of strings to look for in the tree
+            starting from the outermost layer.
         default_value
-            The value to return if key is not found
-        """
-        return self[key] if key in self._children else default_value
+            The value to return if and only if the *final* key in the key path
+            does not exist.
 
-    def get_tree(self, key: str) -> LayeredConfigTree:
-        """Return the LayeredConfigTree at the key in the outermost layer of the config tree.
+        Notes
+        -----
+        The ``default_value`` will only be used if *final* key in the key path
+        does not exist *but the rest of the key path does*.
+
+        Returns
+        -------
+        The value at the key or nested keys. If the key path exists except for the
+        final value, the ``default_value`` is returned.
+        """
+        if not isinstance(keys, (str, list)):
+            raise TypeError("The 'keys' parameter must be a string or a list of strings.")
+
+        if isinstance(keys, str):
+            return self[keys] if keys in self._children else default_value
+        else:
+            # get the second-to-last value (which is by definition a LayeredConfigTree)
+            data = self.get_tree(keys[:-1])
+            return data[keys[-1]] if keys[-1] in data._children else default_value
+
+    def get_tree(self, keys: str | list[str]) -> LayeredConfigTree:
+        """Return the LayeredConfigTree at the key or key path from the outermost layer.
 
         Parameters
         ----------
-        key
-            The str we look up in the outermost layer of the config tree.
+        keys
+            The key or key path to look up from the outermost layer.
+
+        Returns
+        -------
+        The ``LayeredConfigTree`` located at the key or key path provided starting
+        from the outermost layer.
+
+        Raises
+        ------
+        TypeError
+            If the ``keys`` parameter is not a string or list of strings.
+        ConfigurationKeyError
+            If any of the keys in the key path do not exist in the tree.
+        ConfigurationError
+            If the data at the final key in the key path is not a
+            :class:`LayeredConfigTree`.
         """
-        data = self[key]
-        if isinstance(data, LayeredConfigTree):
-            return data
-        else:
+        if not isinstance(keys, (str, list)):
+            raise TypeError("The 'keys' parameter must be a string or a list of strings.")
+
+        if isinstance(keys, str):
+            keys = [keys]
+
+        data = self
+        for key in keys:
+            if key not in data:
+                raise ConfigurationKeyError(
+                    f"No value at key mapping '{keys[:keys.index(key) + 1]}'."
+                )
+            data = data[key]
+        if not isinstance(data, LayeredConfigTree):
             raise ConfigurationError(
-                f"The data you accessed using {key} with get_tree was of type {type(data)}, but get_tree must return a LayeredConfigTree."
+                f"The data you accessed using {keys} with get_tree was of type {type(data)}, "
+                "but get_tree must return a LayeredConfigTree."
             )
+        return data
 
     def get_from_layer(self, name: str, layer: str | None = None) -> Any:
         """Get a configuration value from the provided layer.

--- a/src/layered_config_tree/main.py
+++ b/src/layered_config_tree/main.py
@@ -375,8 +375,8 @@ class LayeredConfigTree:
             return self[keys] if keys in self._children else default_value
         else:
             # get the second-to-last value (which is by definition a LayeredConfigTree)
-            data = self.get_tree(keys[:-1])
-            return data[keys[-1]] if keys[-1] in data._children else default_value
+            tree = self.get_tree(keys[:-1])
+            return tree[keys[-1]] if keys[-1] in tree._children else default_value
 
     def get_tree(self, keys: str | list[str]) -> LayeredConfigTree:
         """Return the LayeredConfigTree at the key or key path from the outermost layer.
@@ -407,19 +407,19 @@ class LayeredConfigTree:
         if isinstance(keys, str):
             keys = [keys]
 
-        data = self
+        tree = self
         for key in keys:
-            if key not in data:
+            if key not in tree:
                 raise ConfigurationKeyError(
                     f"No value at key mapping '{keys[:keys.index(key) + 1]}'."
                 )
-            data = data[key]
-        if not isinstance(data, LayeredConfigTree):
+            tree = tree[key]
+        if not isinstance(tree, LayeredConfigTree):
             raise ConfigurationError(
-                f"The data you accessed using {keys} with get_tree was of type {type(data)}, "
+                f"The data you accessed using {keys} with get_tree was of type {type(tree)}, "
                 "but get_tree must return a LayeredConfigTree."
             )
-        return data
+        return tree
 
     def get_from_layer(self, name: str, layer: str | None = None) -> Any:
         """Get a configuration value from the provided layer.


### PR DESCRIPTION
## Support getting a nested value from a single 'get()' or 'get_tree()' call

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5488

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This slightly extends the existing `.get()` and `get_tree()` methods
to allow for a list of keys to be passed in and then it returns the
nested value.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests updated and all pass